### PR TITLE
refactor appx-require pattern to accept api version and module depends

### DIFF
--- a/lib/appx-test-support.js
+++ b/lib/appx-test-support.js
@@ -59,14 +59,26 @@ class TestSupport {
   }
 }
 
-function requireRest(resource, name, additionalContext) {
+function requireRest(resource, name, additionalContext, apiVersion, dependsOn) {
     const ts = new TestSupport(resource).addToContext(additionalContext);
+    if (apiVersion) {
+      ts.useApiVersion(apiVersion);
+    }
+    if (dependsOn) {
+      ts.dependsOn(dependsOn);
+    }
     const runnable = ts.useRest();
     return r(name, runnable);
 }
 
-function requireLocal(resource, name, additionalContext) {
+function requireLocal(resource, name, additionalContext, apiVersion, dependsOn) {
     const ts = new TestSupport(resource).addToContext(additionalContext);
+    if (apiVersion) {
+      ts.useApiVersion(apiVersion);
+    }
+    if (dependsOn) {
+      ts.dependsOn(dependsOn);
+    }
     return {
         seed: (store) => {
             store = store || {};

--- a/test/appx-test-support.spec.js
+++ b/test/appx-test-support.spec.js
@@ -83,6 +83,13 @@ describe('axus-test-support', () => {
       .useLocal();
      ctx.testCustomTableProviderDependency();
     });
+
+    it('allows the consumption and lookup of additional digests (alternative requires pattern)', () => {
+      let ctx = axus
+       .requireLocal('./test/resources/testModule', undefined, {console: console}, '3.1.0', './test/resources/RequiredDocsTable')
+       .seed();
+      ctx.testCustomTableProviderDependency();
+     });
   });
 
   describe('defrost', () => {
@@ -103,17 +110,23 @@ describe('axus-test-support', () => {
 
   describe('register API version', () => {
     it('can default contextualized API binding', () => {
-      let ctx = axus.require('./test/resources/testModule').useLocal();
-      expect(ctx.Providers.bridge.apiVersion).to.equal('310');
+      let ctx1 = axus.require('./test/resources/testModule').useLocal();
+      let ctx2 = axus.requireLocal('./test/resources/testModule', undefined, undefined, '3.1.0').seed();
+
+      expect(ctx1.Providers.bridge.apiVersion).to.equal('310');
+      expect(ctx2.Providers.bridge.apiVersion).to.equal('3.1.0');
     });
 
     it('can register contextualized API bindings', () => {
       let ctx1 = axus.require('./test/resources/testModule').useApiVersion('3.1.0').useLocal();
       let ctx2 = axus.require('./test/resources/testModule').useApiVersion('3.2.0').useRest();
+      let ctx3 = axus.requireLocal('./test/resources/testModule', undefined, undefined,'3.1.0').seed();
+      let ctx4 = axus.requireRest('./test/resources/testModule', undefined, undefined,'3.2.0');
 
       expect(ctx1.Providers.bridge.apiVersion).to.equal('3.1.0');
       expect(ctx2.Providers.bridge.apiVersion).to.equal('3.2.0');
+      expect(ctx3.Providers.bridge.apiVersion).to.equal('3.1.0');
+      expect(ctx4.Providers.bridge.apiVersion).to.equal('3.2.0');
     });
   });
-
 });


### PR DESCRIPTION
New appx-requires signature pattern:

requireLocal(modulePath, moduleName, additionalContext, apiVersion, dependsOn)
requireRest(modulePath, moduleName, additionalContext, apiVersion, dependsOn)